### PR TITLE
Fix default characterIds in story creation

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -161,9 +161,9 @@ export class MemStorage implements IStorage {
       ...insertStory, 
       id, 
       createdAt: now,
-      userId: insertStory.userId || null,
+      userId: insertStory.userId ?? null,
       soundEffects,
-      characterIds: insertStory.characterIds || null
+      characterIds: insertStory.characterIds ?? []
     };
     
     this.stories.set(id, story);


### PR DESCRIPTION
## Summary
- fix incorrect default for characterIds in `MemStorage.createStory`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6842e39ab6dc832a8cda51f3da002639